### PR TITLE
feat: navigate to Home on clicking the logo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlasify",
   "version": "0.1.0",
-  "description": "Atlassian Notifications on your menu bar.",
+  "description": "Atlassian notifications on your menu bar.",
   "main": "src/electron/main.js",
   "scripts": {
     "build": "webpack --config webpack.prod.js",

--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -59,7 +59,7 @@ describe('components/Sidebar.tsx', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('should open the atlasify repository', () => {
+  it('should navigate to home', () => {
     render(
       <AppContext.Provider
         value={{
@@ -67,6 +67,7 @@ describe('components/Sidebar.tsx', () => {
           notifications: [],
           auth: mockAuth,
           settings: mockSettings,
+          fetchNotifications,
         }}
       >
         <MemoryRouter>
@@ -75,12 +76,9 @@ describe('components/Sidebar.tsx', () => {
       </AppContext.Provider>,
     );
 
-    fireEvent.click(screen.getByTitle('Open Atlasify on GitHub'));
-
-    expect(openExternalLinkMock).toHaveBeenCalledTimes(1);
-    expect(openExternalLinkMock).toHaveBeenCalledWith(
-      'https://github.com/setchy/atlasify',
-    );
+    fireEvent.click(screen.getByTitle('Home'));
+    expect(fetchNotifications).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenNthCalledWith(1, '/', { replace: true });
   });
 
   describe.skip('quick links', () => {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,7 +16,7 @@ import Toggle from '@atlaskit/toggle';
 import { AppContext } from '../context/App';
 import { quitApp } from '../utils/comms';
 import { getFilterCount } from '../utils/helpers';
-import { openAtlasifyRepository, openMyNotifications } from '../utils/links';
+import { openMyNotifications } from '../utils/links';
 import { getNotificationCount } from '../utils/notifications';
 
 export const Sidebar: FC = () => {
@@ -72,9 +72,9 @@ export const Sidebar: FC = () => {
       <div className="flex flex-1 flex-col items-center py-4">
         <div className="mx-auto my-3">
           <Button
-            title="Open Atlasify on GitHub"
+            title="Home"
             appearance="subtle"
-            onClick={() => openAtlasifyRepository()}
+            onClick={() => refreshNotifications()}
           >
             <AtlasIcon size="medium" appearance="inverse" />
           </Button>

--- a/src/components/__snapshots__/Sidebar.test.tsx.snap
+++ b/src/components/__snapshots__/Sidebar.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
           >
             <button
               class=" css-1aearyh"
-              title="Open Atlasify on GitHub"
+              title="Home"
               type="button"
             >
               <span
@@ -173,7 +173,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged in) 
         >
           <button
             class=" css-1aearyh"
-            title="Open Atlasify on GitHub"
+            title="Home"
             type="button"
           >
             <span
@@ -387,7 +387,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
           >
             <button
               class=" css-1aearyh"
-              title="Open Atlasify on GitHub"
+              title="Home"
               type="button"
             >
               <span
@@ -544,7 +544,7 @@ exports[`components/Sidebar.tsx should render itself & its children (logged out)
         >
           <button
             class=" css-1aearyh"
-            title="Open Atlasify on GitHub"
+            title="Home"
             type="button"
           >
             <span

--- a/src/routes/Filters.test.tsx
+++ b/src/routes/Filters.test.tsx
@@ -76,7 +76,7 @@ describe('routes/Filters.tsx', () => {
         );
       });
 
-      fireEvent.click(screen.getByTitle('Clear filters'));
+      fireEvent.click(screen.getByTitle('Clear Filters'));
 
       expect(clearFilters).toHaveBeenCalled();
     });

--- a/src/routes/Filters.tsx
+++ b/src/routes/Filters.tsx
@@ -162,12 +162,12 @@ export const FiltersRoute: FC = () => {
         <Box padding="space.100">
           <Flex justifyContent="end">
             <Button
-              title="Clear filters"
+              title="Clear Filters"
               onClick={clearFilters}
               appearance="discovery"
               spacing="compact"
             >
-              Clear filters
+              Clear Filters
             </Button>
           </Flex>
         </Box>

--- a/src/routes/__snapshots__/Filters.test.tsx.snap
+++ b/src/routes/__snapshots__/Filters.test.tsx.snap
@@ -897,13 +897,13 @@ exports[`routes/Filters.tsx General should render itself & its children 1`] = `
       >
         <button
           class=" css-sxpr96"
-          title="Clear filters"
+          title="Clear Filters"
           type="button"
         >
           <span
             class=" css-1nqby2s"
           >
-            Clear filters
+            Clear Filters
           </span>
         </button>
       </div>

--- a/src/utils/links.test.ts
+++ b/src/utils/links.test.ts
@@ -4,7 +4,6 @@ import * as comms from './comms';
 import {
   openAccountProfile,
   openAtlasifyReleaseNotes,
-  openAtlasifyRepository,
   openMyNotifications,
   openMyPullRequests,
   openNotification,
@@ -17,13 +16,6 @@ describe('utils/links.ts', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-  });
-
-  it('openAtlasifyRepository', () => {
-    openAtlasifyRepository();
-    expect(openExternalLinkMock).toHaveBeenCalledWith(
-      'https://github.com/setchy/atlasify',
-    );
   });
 
   it('openAtlasifyReleaseNotes', () => {

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -2,10 +2,6 @@ import type { Account, AtlasifyNotification, Link } from '../types';
 import { openExternalLink } from './comms';
 import { Constants } from './constants';
 
-export function openAtlasifyRepository() {
-  openExternalLink(`https://github.com/${Constants.REPO_SLUG}` as Link);
-}
-
 export function openAtlasifyReleaseNotes(version: string) {
   openExternalLink(
     `https://github.com/${Constants.REPO_SLUG}/releases/tag/${version}` as Link,


### PR DESCRIPTION
This fixes #36 
Instead of opening the GitHub repo, clicking the Atlasify logo will navigate to the home page to view notifications.

Since Settings --> Release Notes already goes to the Github repo, figured it would be ok to not have that "Open Github repo" navigation in the app elsewhere