### PR TITLE
feat: change icon to navigate home

### DIFF
--- a/src/components/Sidebar.test.tsx
+++ b/src/components/Sidebar.test.tsx
@@ -77,7 +77,6 @@ describe('components/Sidebar.tsx', () => {
     );
 
     fireEvent.click(screen.getByTitle('Home'));
-    expect(fetchNotifications).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenNthCalledWith(1, '/', { replace: true });
   });
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -74,7 +74,7 @@ export const Sidebar: FC = () => {
           <Button
             title="Home"
             appearance="subtle"
-            onClick={() => refreshNotifications()}
+            onClick={() => navigate('/', { replace: true })}
           >
             <AtlasIcon size="medium" appearance="inverse" />
           </Button>


### PR DESCRIPTION
Change to only navigate home and not perform a notification refresh.  May change this behavior in future...