### PR TITLE
feat: remove app name from native notification title

### DIFF
--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -88,7 +88,7 @@ export const raiseNativeNotification = (
 
   if (notifications.length === 1) {
     const notification = notifications[0];
-    title = `${isWindows() ? '' : 'Atlasify - '}${notification.title}`;
+    title = isWindows() ? '' : notification.title;
     body = notification.entity.title; // TODO Confirm this mapping
   } else {
     title = 'Atlasify';


### PR DESCRIPTION
I can't see a good reason for `Atlasify` to be included in the native notification title.  It takes up space which is better suited to the update title. 